### PR TITLE
Audio Filters for Model 1 and Model 2 Genesis

### DIFF
--- a/Genesis.qsf
+++ b/Genesis.qsf
@@ -364,6 +364,8 @@ set_global_assignment -name VHDL_FILE vdp.vhd
 set_global_assignment -name VERILOG_FILE gen_io.v
 set_global_assignment -name SYSTEMVERILOG_FILE teamplayer.sv
 set_global_assignment -name VERILOG_FILE fourway.v
+set_global_assignment -name VERILOG_FILE audio_iir_filter.v
+set_global_assignment -name VERILOG_FILE genesis_lpf.v
 set_global_assignment -name SYSTEMVERILOG_FILE multitap.sv
 set_global_assignment -name SYSTEMVERILOG_FILE system.sv
 set_global_assignment -name SYSTEMVERILOG_FILE Genesis.sv

--- a/Genesis.qsf
+++ b/Genesis.qsf
@@ -371,6 +371,8 @@ set_global_assignment -name VHDL_FILE vdp.vhd
 set_global_assignment -name VERILOG_FILE gen_io.v
 set_global_assignment -name SYSTEMVERILOG_FILE teamplayer.sv
 set_global_assignment -name VERILOG_FILE fourway.v
+set_global_assignment -name VERILOG_FILE audio_iir_filter.v
+set_global_assignment -name VERILOG_FILE genesis_lpf.v
 set_global_assignment -name SYSTEMVERILOG_FILE multitap.sv
 set_global_assignment -name SYSTEMVERILOG_FILE system.sv
 set_global_assignment -name SYSTEMVERILOG_FILE Genesis.sv

--- a/Genesis.sv
+++ b/Genesis.sv
@@ -160,6 +160,7 @@ localparam CONF_STR3 = {
 	"OLM,Multitap,Disabled,4-Way,TeamPlayer,J-Cart;",
 	"OIJ,Mouse,None,Port1,Port2;",
 	"OK,Mouse Flip Y,No,Yes;",
+	"OEF,Audio Filter,Model 1,Model 2,Minimal,No Filter;",
 	"-;",
 `ifdef SOUND_DBG
 	"OB,Enable FM,Yes,No;",
@@ -308,6 +309,8 @@ system system
 	.ENABLE_FM(1),
 	.ENABLE_PSG(1),
 `endif
+
+	.LPF_MODE(status[15:14]),
 
 	.BRAM_A({sd_lba[6:0],sd_buff_addr}),
 	.BRAM_DI(sd_buff_dout),

--- a/audio_iir_filter.v
+++ b/audio_iir_filter.v
@@ -1,0 +1,173 @@
+/*MIT License
+
+Copyright (c) 2019 Gregory Hogan (Soltan_G42)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.*/
+
+module iir_1st_order
+#(
+	parameter COEFF_WIDTH = 18,
+	parameter COEFF_SCALE = 15,
+	parameter DATA_WIDTH  = 16,
+	parameter COUNT_BITS  = 10
+)
+(
+	input clk,
+	input reset,
+	input [COUNT_BITS - 1 : 0] div,
+	input signed [COEFF_WIDTH - 1 : 0] A2, B1, B2,
+   input signed [DATA_WIDTH - 1 :0] in,
+   output [DATA_WIDTH - 1:0] out
+);
+
+	reg signed [DATA_WIDTH-1:0] x0,x1,y0;
+	reg signed [DATA_WIDTH + COEFF_WIDTH - 1 : 0] out32;
+	reg [COUNT_BITS - 1:0] count;
+ 
+ // Usage:
+ // Design your 1st order iir low/high-pass with a tool that will give you the
+ // filter coefficients for the difference equation.  Filter coefficients can
+ // be generated in Octave/matlab/scipy using a command similar to
+ // [B, A] = butter( 1, 3500/(106528/2), 'low') for a 3500 hz 1st order low-pass
+ // assuming 106528Hz sample rate.
+ // 
+ // The Matlab output is:
+ // B = [0.093863   0.093863]
+ // A = [1.00000  -0.81227]
+ //
+ // Then scale coefficients by multiplying by 2^COEFF_SCALE and round to nearest integer
+ //
+ // B = [3076   3076]
+ // A = [32768 -26616]
+ //
+ // Discard A(1) because it is assumed 1.0 before scaling
+ //
+ // This leaves you with A2 = -26616 , B1 = 3076 , B2 = 3076
+ // B1 + B2 - A2  should sum to 2^COEFF_SCALE = 32768
+ //
+ // Sample frequency is "clk rate/div": for Genesis this is 53.69mhz/504 = 106528hz
+ //
+ // COEFF_WIDTH must be at least COEFF_SCALE+1 and must be large enough to
+ // handle temporary overflow during this computation: out32 <= (B1*x0 + B2*x1) - A2*y0
+ 
+	assign out = y0;
+ 
+	always @ (*) begin
+		out32 <= (B1*x0 + B2*x1) - A2*y0; //Previous output is y0 not y1
+	end
+	
+	always @ (posedge clk) begin
+		if(reset) begin
+			count <= 0;
+			x0 <= 0;
+			x1 <= 0;
+			y0 <= 0;
+		end
+		else begin
+			count <= count + 1;
+			if (count == div - 1) begin
+					count <= 0;
+					y0 <= {out32[DATA_WIDTH + COEFF_WIDTH - 1] , out32[COEFF_SCALE + DATA_WIDTH - 2 : COEFF_SCALE]};
+					x1 <= x0;
+					x0 <= in;
+			end
+		end
+	end
+	
+endmodule //iir_1st_order
+
+module iir_2nd_order
+#(
+	parameter COEFF_WIDTH = 18,
+	parameter COEFF_SCALE = 14,
+	parameter DATA_WIDTH  = 16,
+	parameter COUNT_BITS  = 10
+)
+(
+	input clk,
+	input reset,
+	input [COUNT_BITS - 1 : 0] div,
+	input signed [COEFF_WIDTH - 1 : 0] A2, A3, B1, B2, B3,
+   input signed [DATA_WIDTH - 1 : 0] in,
+   output [DATA_WIDTH - 1 : 0] out
+);
+
+	reg signed [DATA_WIDTH-1 : 0] x0,x1,x2;
+	reg signed [DATA_WIDTH-1 : 0] y0,y1;
+	reg signed [(DATA_WIDTH + COEFF_WIDTH - 1) : 0] out32;
+	reg [COUNT_BITS : 0] count;
+ 
+ 
+ // Usage:
+ // Design your 1st order iir low/high-pass with a tool that will give you the
+ // filter coefficients for the difference equation.  Filter coefficients can
+ // be generated in Octave/matlab/scipy using a command similar to
+ // [B, A] = butter( 2, 5000/(48000/2), 'low') for a 5000 hz 2nd order low-pass
+ // assuming 48000Hz sample rate.
+ // 
+ // Output is:
+ // B = [ 0.072231   0.144462   0.072231]
+ // A = [1.00000  -1.10923   0.39815]
+ //
+ // Then scale coefficients by multiplying by 2^COEFF_SCALE and round to nearest integer
+ // Make sure your coefficients can be stored as a signed number with COEFF_WIDTH bits.
+ //
+ // B = [1183   2367   1183]
+ // A = [16384  -18174    6523]
+ //
+ // Discard A(1) because it is assumed 1.0 before scaling
+ //
+ // This leaves you with A2 = -18174 , A3 = 6523, B1 = 1183 , B2 = 2367 , B3 = 1183
+ // B1 + B2 + B3 - A2 - A3 should sum to 2^COEFF_SCALE = 16384
+ //
+ // Sample frequency is "clk rate/div" 
+ //
+ // COEFF_WIDTH must be at least COEFF_SCALE+1 and must be large enough to
+ // handle temporary overflow during this computation: 
+ // out32 <= (B1*x0 + B2*x1 + B3*x2) - (A2*y0 + A3*y1);
+ 
+	assign out = y0;
+ 
+	always @ (*) begin
+		out32 <= (B1*x0 + B2*x1 + B3*x2) - (A2*y0 + A3*y1); //Previous output is y0 not y1
+	end
+	
+	always @ (posedge clk) begin
+		if(reset) begin
+			count <=  0;
+			x0 <= 0;
+			x1 <= 0;
+			x2 <= 0;
+			y0 <= 0;
+			y1 <= 0; 
+		end
+		else begin
+			count <= count + 1;
+			if (count == div - 1) begin
+					count <= 0;
+					y1 <= y0;
+					y0 <= {out32[DATA_WIDTH + COEFF_WIDTH - 1] , out32[(DATA_WIDTH + COEFF_SCALE - 2) : COEFF_SCALE]};
+					x2 <= x1;
+					x1 <= x0;
+					x0 <= in;
+			end
+		end
+	end
+	
+endmodule //iir_2nd_order

--- a/genesis_lpf.v
+++ b/genesis_lpf.v
@@ -1,0 +1,102 @@
+/*MIT License
+
+Copyright (c) 2019 Gregory Hogan (Soltan_G42)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.*/
+
+// This module is intended to be used from system.sv to low pass Genesis audio.
+// Both Model 1 and Model 2 Genesis models have a global 1st order low-pass
+// audio filter. The model 2 has an addition 2nd order low-pass for FM audio
+
+module genesis_lpf(
+	input clk,
+	input reset,
+	input [1:0] lpf_mode,
+   input signed [15:0] in,
+   output signed [15:0] out);
+	
+	reg [9:0] div = 504; //For genesis we'll sample at 53.69mhz/504 = 106528 Hz
+	
+	//Coefficients computed with Octave/Matlab/Online filter calculators.
+	//or with scipy.signal.bessel or similar tools
+	reg signed [17:0] A2;
+	reg signed [17:0] B2;
+	reg signed [17:0] B1;
+	
+	wire signed [15:0] audio_post_lpf1;
+		
+	always @ (*) begin
+		case(lpf_mode[1:0])
+			2'b00 : begin //Model 1 Low Pass at 3.1khz with adjusted slope
+				A2 = -18'd27504;
+				B1 =  18'd10528;
+				B2 = -18'd5264;
+			end
+			2'b01 : begin  //model 2 is measured around 3.96khz
+				A2 = -18'sd26328;
+				B1 =  18'sd12888;
+				B2 = -18'sd6440;
+			end
+			2'b10  : begin  //8.5khz low pass as a "Minimal" filter.
+				A2 = -18'd19088;
+				B1 =  18'd6840;
+				B2 =  18'd6840;
+			end
+			default: begin //Space for a 4th filter. This filter is not used
+				A2 = -18'sd32768; 
+				B1 =  18'sd0; 
+				B2 =  18'sd0;
+			end
+		endcase
+	end
+	
+	iir_1st_order lpf6db(.clk(clk),
+								.reset(reset),
+								.div(div),
+								.A2(A2),
+								.B1(B1),
+								.B2(B2),
+								.in(in),
+								.out(audio_post_lpf1)); 
+	 
+	assign out = ( lpf_mode[1:0] == 2'b11 ) ? in : audio_post_lpf1;
+
+endmodule //genesis_lpf
+
+//This module is intended to be used from system.sv to filter the FM sound before it's mixed with PSG.
+//The model 2 genesis has such a filter. The model 1 has only a global low-pass 
+module genesis_fm_lpf(
+	input clk,
+	input reset,
+   input signed [15:0] in,
+   output signed [15:0] out);
+
+	wire signed [15:0] middle;
+	 
+	iir_2nd_order fm2(.clk(clk),
+							.reset(reset),
+							.div(10'd504), //Divider for 106528hz
+							.A2(-18'sd24704),
+							.A3(18'sd10728),
+							.B1(18'sd1083),
+							.B2(18'sd1204),
+							.B3(18'sd121),
+							.in(in),
+						.out(out));
+endmodule //genesis_fm_lpf


### PR DESCRIPTION
Implements 6db and 12db/octave audio filters to match Model 1 and Model 2 Genesis.
Adds OSD options to select filter: Model1/Model2/Minimal/No Filter