### PR TITLE
correct aspect ratio, add square pixel option for H40

### DIFF
--- a/Genesis.sv
+++ b/Genesis.sv
@@ -183,7 +183,7 @@ localparam CONF_STR = {
 	"D0RH,Save Backup RAM;",
 	"D0OD,Autosave,No,Yes;",
 	"-;",
-	"OA,Aspect ratio,4:3,16:9;",
+	"OA,Aspect Ratio,4:3,16:9;",
 	"OU,320x224 Aspect,Original,Corrected;",
 	"O13,Scandoubler Fx,None,HQ2x,CRT 25%,CRT 50%,CRT 75%;",
 	"OT,Border,No,Yes;",

--- a/system.sv
+++ b/system.sv
@@ -80,6 +80,7 @@ module system
 
 	output        INTERLACE,
 	output        FIELD,
+	output  [1:0] AR_FLAGS,
 
 	input         J3BUT,
 	input  [11:0] JOY_1,
@@ -393,6 +394,7 @@ reg vram32_ack;
 always @(posedge MCLK) vram32_ack <= vram32_req;
 
 wire VDP_hs, VDP_vs;
+//wire [1:0] ar_flags;
 assign HS = ~VDP_hs;
 assign VS = ~VDP_vs;
 
@@ -443,6 +445,7 @@ vdp vdp
 
 	.FIELD_OUT(FIELD),
 	.INTERLACE(INTERLACE),
+	.AR_FLAGS(AR_FLAGS),
 
 	.PAL(PAL),
 	.R(RED),

--- a/vdp.vhd
+++ b/vdp.vhd
@@ -92,6 +92,7 @@ entity vdp is
 		CE_PIX      : buffer std_logic;
 		FIELD_OUT   : out std_logic;
 		INTERLACE   : out std_logic;
+		AR_FLAGS    : out std_logic_vector(1 downto 0);
 		HBL         : out std_logic;
 		VBL         : out std_logic;
 
@@ -2736,6 +2737,8 @@ G <= FF_G;
 B <= FF_B;
 
 INTERLACE <= LSM(1) and LSM(0);
+AR_FLAGS(0) <= H40;
+AR_FLAGS(1) <= V30;
 
 V_DISP_HEIGHT_R <= conv_std_logic_vector(V_DISP_HEIGHT_V30, 9) when V30_R ='1'
               else conv_std_logic_vector(V_DISP_HEIGHT_V28, 9);


### PR DESCRIPTION
-Corrected Aspect for H32 mode
-Corrected Aspect for H40 mode
-Added option to make H40 mode auto-switch to square pixels

The genesis has a quirk such that games that use 320x224 mode look "squashed" on a normal CRT or 4:3 display. The extra option will switch to square pixels for only H40 mode, which many people will find nicer.

Both H32 and H40 pass linearity tests now for 4:3.