### PR TITLE
Fix FM Busy behavior for Hellfire 

### DIFF
--- a/Genesis.sv
+++ b/Genesis.sv
@@ -350,6 +350,7 @@ system system
 	.NORAM_QUIRK(noram_quirk),
 	.PIER_QUIRK(pier_quirk),
 	.TTN2_QUIRK(ttn2_quirk),
+	.FMBUSY_QUIRK(fmbusy_quirk),
 
 	.DAC_LDATA(AUDIO_L),
 	.DAC_RDATA(AUDIO_R),
@@ -603,12 +604,13 @@ reg noram_quirk = 0;
 reg pier_quirk = 0;
 reg ttn2_quirk = 0;
 reg svp_quirk = 0;
+reg fmbusy_quirk = 0;
 always @(posedge clk_sys) begin
 	reg [63:0] cart_id;
 	reg old_download;
 	old_download <= cart_download;
 
-	if(~old_download && cart_download) {fifo_quirk,eeprom_quirk,sram_quirk,noram_quirk,pier_quirk,ttn2_quirk,svp_quirk} <= 0;
+	if(~old_download && cart_download) {fifo_quirk,eeprom_quirk,sram_quirk,noram_quirk,pier_quirk,ttn2_quirk,svp_quirk,fmbusy_quirk} <= 0;
 
 	if(ioctl_wr & cart_download) begin
 		if(ioctl_addr == 'h182) cart_id[63:56] <= ioctl_data[15:8];
@@ -638,6 +640,9 @@ always @(posedge clk_sys) begin
 			else if(cart_id == "TITAN002") ttn2_quirk   <= 1; // Titan Overdrive 2
 			else if(cart_id == "MK-1229 ") svp_quirk    <= 1; // Virtua Racing EU/US
 			else if(cart_id == "G-7001  ") svp_quirk    <= 1; // Virtua Racing JP
+			else if(cart_id == "T-35036 ") fmbusy_quirk <= 1; // Hellfire US
+			else if(cart_id == "T-25073 ") fmbusy_quirk <= 1; // Hellfire JP
+			else if(cart_id == "MK-1137-") fmbusy_quirk <= 1; // Hellfire EU
 		end
 	end
 end

--- a/system.sv
+++ b/system.sv
@@ -54,6 +54,7 @@ module system
 	input         PIER_QUIRK,
 	input         TTN2_QUIRK,
 	input         SVP_QUIRK, 
+	input         FMBUSY_QUIRK,
 
 	input   [1:0] TURBO,
 
@@ -1087,11 +1088,13 @@ end
 
 wire       Z80_ZBUS  = ~Z80_A[15] && ~&Z80_A[14:8];
 
+wire       ZBUS_NO_BUSY = ZBUS_A[14] && ~|ZBUS_A[13:2] && |ZBUS_A[1:0] && FMBUSY_QUIRK;
+
 reg        ZBUS_SEL;
 reg [14:0] ZBUS_A;
 reg        ZBUS_WE;
 reg  [7:0] ZBUS_DO;
-wire [7:0] ZBUS_DI = ZRAM_SEL ? ZRAM_DO : FM_SEL ? FM_DO : 8'hFF;
+wire [7:0] ZBUS_DI = ZRAM_SEL ? ZRAM_DO : (FM_SEL ? (ZBUS_NO_BUSY ? {1'b0, FM_DO[6:0]} : FM_DO) : 8'hFF);
 
 reg  [7:0] MBUS_ZBUS_D;
 reg  [7:0] Z80_ZBUS_D;


### PR DESCRIPTION
Hellfire relies on FM Busy flag behavior of discreet YM2612 to run correctly. 