### PR TITLE
Adding an option to increase the per-line sprite limit.

### DIFF
--- a/Genesis.sv
+++ b/Genesis.sv
@@ -198,6 +198,7 @@ localparam CONF_STR = {
 	"OK,Mouse Flip Y,No,Yes;",
 	"-;",
 	"OPQ,CPU Turbo,None,Medium,High;",
+	"OR,Sprite Limit,Normal,High;",
 	"-;",
 `ifdef SOUND_DBG
 	"OB,Enable FM,Yes,No;",
@@ -396,6 +397,8 @@ system system
 `endif
 	.EN_HIFI_PCM(status[23]), // Option "N"
 	.LPF_MODE(status[15:14]),
+
+	.OBJ_LIMIT_HIGH(status[27]),
 
 	.BRAM_A({sd_lba[6:0],sd_buff_addr}),
 	.BRAM_DI(sd_buff_dout),

--- a/sys/pll_q18.qip
+++ b/sys/pll_q18.qip
@@ -1,0 +1,3 @@
+set_global_assignment -name QIP_FILE           [file join $::quartus(qip_path) pll.qip ]
+set_global_assignment -name QIP_FILE           [file join $::quartus(qip_path) pll_hdmi.qip ]
+set_global_assignment -name QIP_FILE           [file join $::quartus(qip_path) pll_cfg.qip ]

--- a/system.sv
+++ b/system.sv
@@ -104,7 +104,8 @@ module system
 	output        ROM_REQ2,
 	input         ROM_ACK2, 
 	
-	input         EN_HIFI_PCM
+	input         EN_HIFI_PCM,
+	input         OBJ_LIMIT_HIGH
 );
 
 reg reset;
@@ -443,6 +444,7 @@ vdp vdp
 	.VSCROLL_BUG(0),
 	.BORDER_EN(BORDER),
 	.SVP_QUIRK(SVP_QUIRK),
+	.OBJ_LIMIT_HIGH_EN(OBJ_LIMIT_HIGH),
 
 	.FIELD_OUT(FIELD),
 	.INTERLACE(INTERLACE),

--- a/vdp_common.vhd
+++ b/vdp_common.vhd
@@ -111,4 +111,7 @@ constant OBJ_MAX_FRAME_H40      : integer := 80;
 constant OBJ_MAX_LINE_H32       : integer := 16;
 constant OBJ_MAX_LINE_H40       : integer := 20;
 
+constant OBJ_MAX_LINE_H32_HIGH  : integer := 32;
+constant OBJ_MAX_LINE_H40_HIGH  : integer := 40;
+
 end vdp_common;


### PR DESCRIPTION
This PR adds the ability to toggle a high sprite limit which will double the max sprite count per line on the Genesis core when enabled.