### PR TITLE
Fix clamping of channels to 9 bits, add YM2612 ladder effect support

### DIFF
--- a/Genesis.sv
+++ b/Genesis.sv
@@ -173,6 +173,13 @@ assign LED_USER  = cart_download | sav_pending;
 
 //`define SOUND_DBG
 
+// Status Bit Map:
+//             Upper                             Lower              
+// 0         1         2         3          4         5         6   
+// 01234567890123456789012345678901 23456789012345678901234567890123
+// 0123456789ABCDEFGHIJKLMNOPQRSTUV 1234567890abcdefghijklmnopqrstuv
+// XXXXXXXXXXXX XXXXXXXXXXXXXXXXXXX                                 
+
 `include "build_id.v"
 localparam CONF_STR = {
 	"Genesis;;",
@@ -195,6 +202,7 @@ localparam CONF_STR = {
 	"OT,Border,No,Yes;",
 	"-;",
 	"OEF,Audio Filter,Model 1,Model 2,Minimal,No Filter;",
+	"OB,FM Chip,YM2612,YM3438;",
 	"ON,HiFi PCM,No,Yes;",
 	"-;",
 	"O4,Swap Joysticks,No,Yes;",
@@ -204,11 +212,11 @@ localparam CONF_STR = {
 	"OK,Mouse Flip Y,No,Yes;",
 	"-;",
 	"OPQ,CPU Turbo,None,Medium,High;",
-	"OR,Sprite Limit,Normal,High;",
+	"OV,Sprite Limit,Normal,High;",
 	"-;",
 `ifdef SOUND_DBG
-	"OB,Enable FM,Yes,No;",
-	"OC,Enable PSG,Yes,No;",
+	"OR,Enable FM,Yes,No;",
+	"OS,Enable PSG,Yes,No;",
 `endif	
 	"R0,Reset;",
 	"J1,A,B,C,Start,Mode,X,Y,Z;",
@@ -401,16 +409,17 @@ system system
 	.MOUSE_OPT(status[20:18]),
 
 `ifdef SOUND_DBG
-	.ENABLE_FM(~status[11]),
-	.ENABLE_PSG(~status[12]),
+	.ENABLE_FM(~status[27]),
+	.ENABLE_PSG(~status[28]),
 `else
 	.ENABLE_FM(1),
 	.ENABLE_PSG(1),
 `endif
 	.EN_HIFI_PCM(status[23]), // Option "N"
+	.LADDER(~status[11]),
 	.LPF_MODE(status[15:14]),
 
-	.OBJ_LIMIT_HIGH(status[27]),
+	.OBJ_LIMIT_HIGH(status[31]),
 
 	.BRAM_A({sd_lba[6:0],sd_buff_addr}),
 	.BRAM_DI(sd_buff_dout),

--- a/jt12/jt12.v
+++ b/jt12/jt12.v
@@ -35,6 +35,7 @@ module jt12 (
     output          irq_n,
     // configuration
     input           en_hifi_pcm,
+    input           ladder,
     // combined output
     output  signed  [15:0]  snd_right,
     output  signed  [15:0]  snd_left,
@@ -55,6 +56,7 @@ jt12_top u_jt12(
     .irq_n  ( irq_n ),
     // configuration
     .en_hifi_pcm    ( en_hifi_pcm ),
+    .ladder         ( ladder ),
     // Unused ADPCM pins
     .adpcma_addr    (      ), // real hardware has 10 pins multiplexed through RMPX pin
     .adpcma_bank    (      ),

--- a/jt12/jt12_acc.v
+++ b/jt12/jt12_acc.v
@@ -37,6 +37,8 @@ module jt12_acc(
     input               rst,
     input               clk,
     input               clk_en,
+    input               ladder,
+    input               channel_en,
     input signed [8:0]  op_result,
     input        [ 1:0] rl,
     input               zero,
@@ -49,8 +51,8 @@ module jt12_acc(
     input               pcm_en, // only enabled for channel 6
     input   signed [8:0] pcm,
     // combined output
-    output reg signed   [11:0]  left,
-    output reg signed   [11:0]  right
+    output reg signed   [15:0]  left,
+    output reg signed   [15:0]  right
 );
 
 reg sum_en;
@@ -72,38 +74,36 @@ always @(posedge clk) if(clk_en)
 
 wire use_pcm = ch6op && pcm_en;
 wire sum_or_pcm = sum_en | use_pcm;
-wire left_en = rl[1];
-wire right_en= rl[0];
 wire signed [8:0] pcm_data = pcm_sum ? pcm : 9'd0;
-wire [8:0] acc_input =  use_pcm ? pcm_data : op_result;
+
+wire signed [8:0] acc_input = ~channel_en ? 9'd0 : (use_pcm ? pcm_data : op_result);
 
 // Continuous output
-wire signed   [11:0]  pre_left, pre_right;
-jt12_single_acc #(.win(9),.wout(12)) u_left(
+wire signed   [8:0]  acc_out;
+jt12_single_acc #(.win(9),.wout(9)) u_acc(
     .clk        ( clk            ),
     .clk_en     ( clk_en         ),
     .op_result  ( acc_input      ),
-    .sum_en     ( sum_or_pcm & left_en ),
+    .sum_en     ( sum_or_pcm     ),
     .zero       ( zero           ),
-    .snd        ( pre_left       )
+    .snd        ( acc_out        )
 );
 
-jt12_single_acc #(.win(9),.wout(12)) u_right(
-    .clk        ( clk            ),
-    .clk_en     ( clk_en         ),
-    .op_result  ( acc_input      ),
-    .sum_en     ( sum_or_pcm & right_en ),
-    .zero       ( zero           ),
-    .snd        ( pre_right      )
-);
+wire signed [15:0] acc_expand = {{7{acc_out[8]}}, acc_out};
 
-// Output can be amplied by 8/6=1.33 to use full range
-// an easy alternative is to add 1/4th and get 1.25 amplification
- //////This is unsafe to do.  The accumulator is adding operators, not channels (up to 24, not 6).
- //////Also, if this was safe, I believe this should be adding pre_left and pre_right, not left and right.
+reg [1:0] rl_latch, rl_old;
+
+wire signed [4:0] ladder_left = ~ladder ? 5'd0 : (acc_expand >= 0 ? 5'd7 : (rl_old[1] ? 5'd0 : -5'd6));
+wire signed [4:0] ladder_right = ~ladder ? 5'd0 : (acc_expand >= 0 ? 5'd7 : (rl_old[0] ? 5'd0 : -5'd6));
+
 always @(posedge clk) if(clk_en) begin
-    left  <= pre_left  - { {2{pre_left [11]}}, pre_left [11:2] };
-    right <= pre_right - { {2{pre_right[11]}}, pre_right[11:2] };
+    if (channel_en)
+        rl_latch <= rl;
+    if (zero)
+        rl_old <= rl_latch;
+
+    left  <= rl_old[1] ? acc_expand + ladder_left : ladder_left;
+    right <= rl_old[0] ? acc_expand + ladder_right : ladder_right;
 end
 
 endmodule


### PR DESCRIPTION
The YM2612 must accumulate the opcodes of it's channels individually, and then be clamped it 9 bit signed values before they are summed, otherwise clipping and balance issues will occur if very loud channels play. Having made that change, I was able to add the YM2612's famous "ladder effect" distortion that a lot of music on the Sega Genesis relies upon to sound correct.

It can be toggled in the main menu under FM Chip option.

Special thanks to James-F, GreyRogue, Ace, and Nukeykt for the info and assistance in making that happen.