### PR TITLE
Smart De-dither for composite blending

### DIFF
--- a/Genesis.qsf
+++ b/Genesis.qsf
@@ -13,7 +13,7 @@ set_global_assignment -name PARTITION_NETLIST_TYPE SOURCE -section_id Top
 set_global_assignment -name PARTITION_FITTER_PRESERVATION_LEVEL PLACEMENT_AND_ROUTING -section_id Top
 set_global_assignment -name PARTITION_COLOR 16764057 -section_id Top
 
-set_global_assignment -name LAST_QUARTUS_VERSION "17.0.2 Standard Edition"
+set_global_assignment -name LAST_QUARTUS_VERSION "17.0.0 Standard Edition"
 
 set_global_assignment -name GENERATE_RBF_FILE ON
 set_global_assignment -name PROJECT_OUTPUT_DIRECTORY output_files

--- a/Genesis.sv
+++ b/Genesis.sv
@@ -494,10 +494,10 @@ wire BGA_DITHER_DETECT;
 wire BGB_DITHER_DETECT;
 
 
-wire cofi_enable = (status[36:34]==3'd1) ||																					// Force on (whole screen).
-						 (status[36:34]==3'd2 && BG_LAYER_ACTIVE && BGA_DITHER_DETECT) ||								// Auto-detect on Background Layer A.
-						 (status[36:34]==3'd3 && BG_LAYER_ACTIVE && BGB_DITHER_DETECT) ||								// Auto-detect on Background Layer B.
-						 (status[36:34]==3'd4 && BG_LAYER_ACTIVE && (BGA_DITHER_DETECT || BGB_DITHER_DETECT));	// Auto-detect on BOTH Background layers.
+wire cofi_enable = (status[36:34]==3'd1) ||																							// Force on (whole screen).
+						 (status[36:34]==3'd2 && /*BG_LAYER_ACTIVE &&*/ BGA_DITHER_DETECT) ||								// Auto-detect on Background Layer A.
+						 (status[36:34]==3'd3 && /*BG_LAYER_ACTIVE &&*/ BGB_DITHER_DETECT) ||								// Auto-detect on Background Layer B.
+						 (status[36:34]==3'd4 && /*BG_LAYER_ACTIVE &&*/ (BGA_DITHER_DETECT || BGB_DITHER_DETECT));	// Auto-detect on BOTH Background layers.
 
 wire PAL = status[7];
 

--- a/Genesis.sv
+++ b/Genesis.sv
@@ -177,7 +177,7 @@ assign LED_USER  = cart_download | sav_pending;
 // 0         1         2         3          4         5         6   
 // 01234567890123456789012345678901 23456789012345678901234567890123
 // 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
-// XXXXXXXXXXXX XXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXX                    
+// XXXXXXXXXXXX XXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXX XXX               
 
 `include "build_id.v"
 localparam CONF_STR = {
@@ -199,7 +199,7 @@ localparam CONF_STR = {
 	"OU,320x224 Aspect,Original,Corrected;",
 	"O13,Scandoubler Fx,None,HQ2x,CRT 25%,CRT 50%,CRT 75%;",
 	"OT,Border,No,Yes;",
-	"o24,Composite Blending,Off,On,AutoBGA,AutoBGB,AutoBoth;",
+	"oEG,Composite Blending,Off,On,AutoBGA,AutoBGB,AutoBoth;",
 	"-;",
 	"OEF,Audio Filter,Model 1,Model 2,Minimal,No Filter;",
 	"OB,FM Chip,YM2612,YM3438;",
@@ -494,10 +494,10 @@ wire BGA_DITHER_DETECT;
 wire BGB_DITHER_DETECT;
 
 
-wire cofi_enable = (status[36:34]==3'd1) ||																							// Force on (whole screen).
-						 (status[36:34]==3'd2 && /*BG_LAYER_ACTIVE &&*/ BGA_DITHER_DETECT) ||								// Auto-detect on Background Layer A.
-						 (status[36:34]==3'd3 && /*BG_LAYER_ACTIVE &&*/ BGB_DITHER_DETECT) ||								// Auto-detect on Background Layer B.
-						 (status[36:34]==3'd4 && /*BG_LAYER_ACTIVE &&*/ (BGA_DITHER_DETECT || BGB_DITHER_DETECT));	// Auto-detect on BOTH Background layers.
+wire cofi_enable = (status[48:46]==3'd1) ||																							// Force on (whole screen).
+						 (status[48:46]==3'd2 && /*BG_LAYER_ACTIVE &&*/ BGA_DITHER_DETECT) ||								// Auto-detect on Background Layer A.
+						 (status[48:46]==3'd3 && /*BG_LAYER_ACTIVE &&*/ BGB_DITHER_DETECT) ||								// Auto-detect on Background Layer B.
+						 (status[48:46]==3'd4 && /*BG_LAYER_ACTIVE &&*/ (BGA_DITHER_DETECT || BGB_DITHER_DETECT));	// Auto-detect on BOTH Background layers.
 
 wire PAL = status[7];
 

--- a/Genesis.sv
+++ b/Genesis.sv
@@ -199,7 +199,7 @@ localparam CONF_STR = {
 	"OU,320x224 Aspect,Original,Corrected;",
 	"O13,Scandoubler Fx,None,HQ2x,CRT 25%,CRT 50%,CRT 75%;",
 	"OT,Border,No,Yes;",
-	"o2,Composite Blending,Off,On;",
+	"o24,Composite Blending,Off,On,AutoBGA,AutoBGB,AutoBoth;",
 	"-;",
 	"OEF,Audio Filter,Model 1,Model 2,Minimal,No Filter;",
 	"OB,FM Chip,YM2612,YM3438;",
@@ -481,8 +481,23 @@ system system
 	.ROM_ADDR2(rom_addr2),
 	.ROM_DATA2(rom_data2),
 	.ROM_REQ2(rom_rd2),
-	.ROM_ACK2(rom_rdack2) 
+	.ROM_ACK2(rom_rdack2),
+	
+	.BG_LAYER_ACTIVE(BG_LAYER_ACTIVE),
+	
+	.BGA_DITHER_DETECT(BGA_DITHER_DETECT),
+	.BGB_DITHER_DETECT(BGB_DITHER_DETECT)
 );
+
+wire BG_LAYER_ACTIVE;
+wire BGA_DITHER_DETECT;
+wire BGB_DITHER_DETECT;
+
+
+wire cofi_enable = (status[36:34]==3'd1) ||																					// Force on (whole screen).
+						 (status[36:34]==3'd2 && BG_LAYER_ACTIVE && BGA_DITHER_DETECT) ||								// Auto-detect on Background Layer A.
+						 (status[36:34]==3'd3 && BG_LAYER_ACTIVE && BGB_DITHER_DETECT) ||								// Auto-detect on Background Layer B.
+						 (status[36:34]==3'd4 && BG_LAYER_ACTIVE && (BGA_DITHER_DETECT || BGB_DITHER_DETECT));	// Auto-detect on BOTH Background layers.
 
 wire PAL = status[7];
 
@@ -545,7 +560,7 @@ wire [7:0] red, green, blue;
 cofi coffee (
 	.clk(clk_sys),
 	.pix_ce(ce_pix),
-	.enable(status[34]),
+	.enable(cofi_enable),
 
 	.hblank(hblank),
 	.vblank(vblank),

--- a/system.sv
+++ b/system.sv
@@ -118,7 +118,11 @@ module system
 	
 	input         EN_HIFI_PCM,
 	input         LADDER,
-	input         OBJ_LIMIT_HIGH
+	input         OBJ_LIMIT_HIGH,
+
+	output		  BG_LAYER_ACTIVE,
+	output		  BGA_DITHER_DETECT,
+	output		  BGB_DITHER_DETECT
 );
 
 reg reset;
@@ -446,8 +450,14 @@ vdp vdp
 	.VS(VDP_vs),
 	.CE_PIX(CE_PIX),
 	.HBL(HBL),
-	.VBL(VBL)
+	.VBL(VBL),
+	
+	.BG_LAYER_ACTIVE(BG_LAYER_ACTIVE),
+	
+	.BGA_DITHER_DETECT(BGA_DITHER_DETECT),
+	.BGB_DITHER_DETECT(BGB_DITHER_DETECT)
 );
+
 
 // PSG 0x10-0x17 in VDP space
 wire signed [10:0] PSG_SND;


### PR DESCRIPTION
This commit adds "Auto" options to the Composite Blending feature.

The logic detects an alternating pattern of "transparent" (zero) and non-transparent pixels on the two background layers.

(and detects the inverse, due to scrolling.)

Rather than blur the whole image at all times, like this...

![Blur_On](https://user-images.githubusercontent.com/24658385/80761491-95701e00-8b32-11ea-9fb1-665e095f73e2.png)

The logic detects the dithering pattern on either Background Layer A, Background Layer B, or Both...

![unknown_1](https://user-images.githubusercontent.com/24658385/80761165-f6e3bd00-8b31-11ea-8cdb-e613d2fccbc2.png)

So it can selectively blur only those parts of the image, and keep the rest looking sharp...

![Blur_Background_A_only](https://user-images.githubusercontent.com/24658385/80761181-fcd99e00-8b31-11ea-88c3-a70bbc9c94d6.png)

This option WILL create some artifacts in certain games when enabled, since some background tiles might use dithering, and the logic will try to blur that.

So some experimentation will be needed to find the best setting for different games, and some might look better with it set to Off or On (full image).

There is also a delay of three pixels for the effect at the moment. That could maybe be fixed by delaying the main pixel output by three pixels, then adjusting the Hsync timing slightly (to shift the whole image slightly towards the left again).

It also can't currently blur pixels on things like the "bridge" tiles in the image above, since the dithering pattern there is baked into the tile pattern itself, and they don't use transparent pixels.
