### PR TITLE
One method of simulating Z80 open bus

### DIFF
--- a/rtl/system.sv
+++ b/rtl/system.sv
@@ -1191,7 +1191,7 @@ T80s #(.T2Write(1)) Z80
 	.RD_n(Z80_RD_N),
 	.WR_n(Z80_WR_N),
 	.A(Z80_A),
-	.DI((~Z80_ZBUS_DTACK_N) ? Z80_ZBUS_D : Z80_MBUS_D),
+	.DI((~Z80_MBUS_DTACK_N) ? Z80_MBUS_D : Z80_ZBUS_D),
 	.DO(Z80_DO)
 );
 
@@ -1282,19 +1282,23 @@ always @(posedge MCLK) begin
 
 		case (zstate)
 		ZBUS_IDLE:
-			if (ZBUS_SEL & MBUS_ZBUS_DTACK_N) begin
-				ZBUS_A <= {MBUS_A[14:1], MBUS_UDS_N};
-				ZBUS_DO <= (~MBUS_UDS_N) ? MBUS_DO[15:8] : MBUS_DO[7:0];
-				ZBUS_WE <= ~MBUS_RNW & ZBUS_FREE;
-				zsrc <= ZSRC_MBUS;
-				zstate <= ZBUS_READ;
-			end
-			else if (Z80_ZBUS_SEL & Z80_ZBUS_DTACK_N) begin
-				ZBUS_A <= Z80_A[14:0];
-				ZBUS_DO <= Z80_DO;
-				ZBUS_WE <= ~Z80_WR_N;
-				zsrc <= ZSRC_Z80;
-				zstate <= ZBUS_READ;
+			begin
+				if (Z80_RD_N)      Z80_ZBUS_D <= 8'hFF;
+
+				if (ZBUS_SEL & MBUS_ZBUS_DTACK_N) begin
+					ZBUS_A <= {MBUS_A[14:1], MBUS_UDS_N};
+					ZBUS_DO <= (~MBUS_UDS_N) ? MBUS_DO[15:8] : MBUS_DO[7:0];
+					ZBUS_WE <= ~MBUS_RNW & ZBUS_FREE;
+					zsrc <= ZSRC_MBUS;
+					zstate <= ZBUS_READ;
+				end
+				else if (Z80_ZBUS_SEL & Z80_ZBUS_DTACK_N) begin
+					ZBUS_A <= Z80_A[14:0];
+					ZBUS_DO <= Z80_DO;
+					ZBUS_WE <= ~Z80_WR_N;
+					zsrc <= ZSRC_Z80;
+					zstate <= ZBUS_READ;
+				end
 			end
 
 		ZBUS_READ:


### PR DESCRIPTION
This is an example of a change that fixes #143 by implementing a sort of open bus behavior for non-read Z80 bus cycles. There are probably several other ways that the intended behavior could be expressed.

Marking this as a draft because I'm not familiar enough with the bus control code to be sure that it's even a particularly safe change, let alone the cleanest way of doing this, and I've only lightly tested it.

In summary, the changes are:

- Change the T80s DI connection so that it defaults to Z80_ZBUS_D instead of Z80_MBUS_D
- Set Z80_ZBUS_D to 8'hFF when in ZBUS_IDLE state and Z80_RD_N is not asserted.

Most of the second hunk is just indentation changes due to adding a begin/end; the first line with "if (Z80_RD_N)"  is the important part.