### PR TITLE
Defaulting SNAC to port 1 to be consistent with other cores.

### DIFF
--- a/Genesis.sv
+++ b/Genesis.sv
@@ -450,8 +450,8 @@ system system
 	.GG_AVAILABLE(gg_available),
 
 	.J3BUT(~status[5]),
-	.JOY_1(status[4] ? joystick_1 : joystick_0),
-	.JOY_2(status[4] ? joystick_0 : joystick_1),
+	.JOY_1(status[4] ^ status[45] ? joystick_1 : joystick_0),
+	.JOY_2(status[4] ^ status[45] ? joystick_0 : joystick_1),
 	.JOY_3(joystick_2),
 	.JOY_4(joystick_3),
 	.JOY_5(joystick_4),
@@ -980,8 +980,8 @@ always @(posedge clk_sys) begin
 		SERJOYSTICK_IN[5] <= USER_IN[6];//c TR GPIO7			
 		SERJOYSTICK_IN[6] <= USER_IN[4];//  TH
 		SERJOYSTICK_IN[7] <= 0;
-		SER_OPT[0] <= status[4];
-		SER_OPT[1] <= ~status[4];
+		SER_OPT[0] <= ~status[4];
+		SER_OPT[1] <= status[4];
 		USER_OUT[1] <= SERJOYSTICK_OUT[0];
 		USER_OUT[0] <= SERJOYSTICK_OUT[1];
 		USER_OUT[5] <= SERJOYSTICK_OUT[2];


### PR DESCRIPTION
I've been getting complaints that SNAC is inconsistent on the Genesis core because it defaulted to port 2, unlike other cores.