### PR TITLE
Revised default button mapping

### DIFF
--- a/Genesis.sv
+++ b/Genesis.sv
@@ -127,7 +127,7 @@ module emu
 assign ADC_BUS  = 'Z;
 assign USER_OUT = '1;
 assign {UART_RTS, UART_TXD, UART_DTR} = 0;
-assign BUTTONS[1]   = 0;
+assign BUTTONS   = 0;
 assign {SD_SCK, SD_MOSI, SD_CS} = 'Z;
 assign {SDRAM_DQ, SDRAM_A, SDRAM_BA, SDRAM_CLK, SDRAM_CKE, SDRAM_DQML, SDRAM_DQMH, SDRAM_nWE, SDRAM_nCAS, SDRAM_nRAS, SDRAM_nCS} = 'Z;
 
@@ -441,23 +441,6 @@ system system
 	.ROM_REQ2(rom_rd2),
 	.ROM_ACK2(rom_rdack2) 
 );
-
-// Pop OSD menu if no rom has been loaded automatically
-assign BUTTONS[0] = osd_btn;
-
-reg osd_btn = 0;
-always @(posedge clk_sys) begin : osd_block
-    integer timeout = 0;
-
-    if(!RESET) begin
-        osd_btn <= 0;
-        if(timeout < 61000000) begin
-            timeout <= timeout + 1;
-            if(timeout > 50000000)
-                osd_btn <= ~cart_download;
-        end
-    end
-end
 
 wire PAL = status[7];
 

--- a/Genesis.sv
+++ b/Genesis.sv
@@ -220,8 +220,8 @@ localparam CONF_STR = {
 	"H3-;",
 	"R0,Reset;",
 	"J1,A,B,C,Start,Mode,X,Y,Z;",
-	"jn,A,B,R,Start,Select,X,Y,L;", // name map to SNES layout.
-	"jp,Y,B,A,Start,Select,L,X,R;", // positional map to SNES layout (3 button friendly) 
+	"jn,Y,B,A,Start,Select,L,X,R;", // positional map to SNES layout (3 button friendly) 
+	"jp,A,B,R,Start,Select,X,Y,L;", // name map to SNES layout.
 	"V,v",`BUILD_DATE
 };
 

--- a/Genesis.sv
+++ b/Genesis.sv
@@ -127,7 +127,7 @@ module emu
 assign ADC_BUS  = 'Z;
 assign USER_OUT = '1;
 assign {UART_RTS, UART_TXD, UART_DTR} = 0;
-assign BUTTONS   = 0;
+assign BUTTONS[1]   = 0;
 assign {SD_SCK, SD_MOSI, SD_CS} = 'Z;
 assign {SDRAM_DQ, SDRAM_A, SDRAM_BA, SDRAM_CLK, SDRAM_CKE, SDRAM_DQML, SDRAM_DQMH, SDRAM_nWE, SDRAM_nCAS, SDRAM_nRAS, SDRAM_nCS} = 'Z;
 
@@ -441,6 +441,23 @@ system system
 	.ROM_REQ2(rom_rd2),
 	.ROM_ACK2(rom_rdack2) 
 );
+
+// Pop OSD menu if no rom has been loaded automatically
+assign BUTTONS[0] = osd_btn;
+
+reg osd_btn = 0;
+always @(posedge clk_sys) begin : osd_block
+    integer timeout = 0;
+
+    if(!RESET) begin
+        osd_btn <= 0;
+        if(timeout < 61000000) begin
+            timeout <= timeout + 1;
+            if(timeout > 50000000)
+                osd_btn <= ~cart_download;
+        end
+    end
+end
 
 wire PAL = status[7];
 


### PR DESCRIPTION
Many Genesis games use C as the main action button. The "name mapping" (current default) puts this on the R shoulder button for SNES style controllers. The "positional map" places the main 3 buttons on the face of SNES style controllers.

This is part of a larger effort to standardize button mapping across the majority of controllers and cores. The scheme is as follows:

SNES  button | SNES controller | NES controller | Genesis controller | Microsoft controller | Sony Controller | NEC Controller | Arcade Controller
------------ | --------------- | -------------- | ------------------ | -------------------- | --------------- | -------------- | -----------------
Y | Y | B | A | X | Square | III | Top left button
B | B | A | B | A | Cross | II | Top middle button
A | A | - | C | B | Circle | I | Top right button
X | X | - | X | Y | Triangle | IV | Bottom left button
L | L | - | Y | LB | L1 | V | Bottom middle button
R | R | - | Z | RB | R1 | VI | Bottom right button
Select | Select | Select | (Mode) | Back | Share | Select | Coin
Start | Start | Start | Start | Start | Option | Run | Start
