### PR TITLE
Fix endcase syntax error

### DIFF
--- a/rtl/sdram.sv
+++ b/rtl/sdram.sv
@@ -225,7 +225,7 @@ always @(posedge clk) begin
 		casex(state)
 			STATE_START: SDRAM_A <= a[13:1];
 			STATE_CONT:  SDRAM_A <= {dqm, 2'b10, a[22:14]};
-		endcase;
+		endcase
 	end
 	else if(mode == MODE_LDM && state == STATE_START) SDRAM_A <= MODE;
 	else if(mode == MODE_PRE && state == STATE_START) SDRAM_A <= 13'b0010000000000;

--- a/rtl/system.sv
+++ b/rtl/system.sv
@@ -1173,9 +1173,9 @@ always @(posedge MCLK) begin
 						VDP_MBUS_DTACK_N <= 0;
 						mstate <= MBUS_IDLE;
 					end
-				endcase;
+				endcase
 			end
-		endcase;
+		endcase
 	end
 end
 


### PR DESCRIPTION
I tested with some test roms to make sure it didn't change anything, I didn't suspect it would be a problem to remove these 3 instances of the semicolon as there are dozens others in a similar way without semicolons.

as per this issue from @grigorovich https://github.com/MiSTer-devel/Genesis_MiSTer/issues/177