### PR TITLE
initialize sram to 0xFF instead of 0x0

### DIFF
--- a/rtl/sdram.sv
+++ b/rtl/sdram.sv
@@ -225,7 +225,7 @@ always @(posedge clk) begin
 		casex(state)
 			STATE_START: SDRAM_A <= a[13:1];
 			STATE_CONT:  SDRAM_A <= {dqm, 2'b10, a[22:14]};
-		endcase;
+		endcase
 	end
 	else if(mode == MODE_LDM && state == STATE_START) SDRAM_A <= MODE;
 	else if(mode == MODE_PRE && state == STATE_START) SDRAM_A <= 13'b0010000000000;

--- a/rtl/system.sv
+++ b/rtl/system.sv
@@ -1173,9 +1173,9 @@ always @(posedge MCLK) begin
 						VDP_MBUS_DTACK_N <= 0;
 						mstate <= MBUS_IDLE;
 					end
-				endcase;
+				endcase
 			end
-		endcase;
+		endcase
 	end
 end
 


### PR DESCRIPTION
Minor change to fix this issue --> MiSTer-devel#170

SRAM is supposed to be initialized to 0xFF not 0x0 according to Sega's technical documentation. Star Trek: The Next Generation - Echoes from the Past freezes if the SRAM is checked and it is not initialized to 0xFF.

Tested and it fixes the issue. However as @ekeeke notes it causes a single romhack game from 2007 to fail to load. Submitting this as a draft until I add a quirk to address this.