### PR TITLE
Controller reset fix for some games that need a particular reset routine (Samurai Shodown)

### DIFF
--- a/rtl/gen_io.sv
+++ b/rtl/gen_io.sv
@@ -341,8 +341,8 @@ always @(posedge RESET or posedge CLK) begin
 
 	if(RESET) begin
 		DTACK_N <= 1;
-		TH   <= 0;
-		JCNT <= 0;
+		TH   <= 1;
+		JCNT <= 3;
 	end
 	else if(CE) begin
 	


### PR DESCRIPTION
Hello folks! This is my very first FPGA work. Thanks to @birdybro for pointing out the issue and answering my questions.

This PR addresses #197. After playing certain games (like Micro Machines), loading Samurai Shodown will result in the game being unplayable due to not accepting any controller inputs. 

Since enabling multitap worked, the key to fixing this issue was looking at what multitap did during reset and replicating the behavior for the pad_io module.

Since this is my very first experience with SystemVerilog, I would appreciate any kind of feedback on whether this could be done better - and what it would look like. I aim to learn more as I pick up issues. It's fun!